### PR TITLE
Publishing to jitpack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
 
 
       - name: Run Gradle Tasks
-        run: ./gradlew build check cleanTest test --continue
+        run: ./gradlew build check cleanTest test publishToMavenLocal --continue

--- a/README.md
+++ b/README.md
@@ -7,6 +7,33 @@ This repo contains 4 jvm packages:
 * [dids](./dids) - did generation and resolution
 * [credentials](./credentials) - creation and verification of verifiable claims
 
+# Quickstart
+
+All the web5 libraries are published on [JitPack](https://jitpack.io). To start simply add the following to your
+`gradle.build.kts` file:
+
+```kotlin
+repositories {
+    maven(url = "https://jitpack.io")
+}
+
+dependencies {
+    implementation("com.github.TBD54566975:web5-sdk-kotlin:master-SNAPSHOT")
+}
+```
+
+If you want to refer to a specific release, then replace the `master-SNAPSHOT` with release tag.
+
+If you want to pull a PR, then replace `master-SNAPSHOT` using the template `PR<NR>-SNAPSHOT`. For example `PR40-SNAPSHOT`.
+
+If you want to depend on a single module, like `credentials`, then use the following dependencies
+```kotlin
+dependencies {
+  implementation("com.github.TBD54566975.web5-sdk-kotlin:credentials:master-SNAPSHOT")
+}
+```
+
+
 # Building
 
 To build and run test just run:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
   id("org.jetbrains.kotlin.jvm") version "1.9.0"
   id("java-library")
   id("io.gitlab.arturbosch.detekt") version "1.23.1"
+  `maven-publish`
 }
 
 repositories {
@@ -14,11 +15,17 @@ dependencies {
   detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.1")
 }
 
+allprojects {
+  version = "0.0.0"
+  group = "web5"
+}
+
 subprojects {
   apply {
     plugin("io.gitlab.arturbosch.detekt")
     plugin("org.jetbrains.kotlin.jvm")
     plugin("java-library")
+    plugin("maven-publish")
   }
 
   tasks.withType<Detekt>().configureEach {
@@ -34,5 +41,21 @@ subprojects {
 
   kotlin {
     explicitApi()
+  }
+
+  java {
+    withJavadocJar()
+    withSourcesJar()
+  }
+
+  publishing {
+    publications {
+      create<MavenPublication>("web5") {
+        groupId = project.group.toString()
+        artifactId = project.name.toString()
+        version = project.version.toString()
+        from(components["java"])
+      }
+    }
   }
 }

--- a/credentials/build.gradle.kts
+++ b/credentials/build.gradle.kts
@@ -3,9 +3,24 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 plugins {
   id("org.jetbrains.kotlin.jvm")
   id("java-library")
+  `maven-publish`
 }
 
-version = "1.0"
+group = "web5"
+version = "0.0.0"
+
+java {
+  withJavadocJar()
+  withSourcesJar()
+}
+
+publishing {
+  publications {
+    create<MavenPublication>("web5Credentials") {
+      from(components["java"])
+    }
+  }
+}
 
 repositories {
   mavenCentral()
@@ -35,10 +50,3 @@ tasks.test {
     showStackTraces = true
   }
 }
-
-// This is needed for IntelliJ unit tests to work in the IDE
-//java {
-//  toolchain {
-//    languageVersion = JavaLanguageVersion.of(20)
-//  }
-//}

--- a/credentials/build.gradle.kts
+++ b/credentials/build.gradle.kts
@@ -3,23 +3,6 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 plugins {
   id("org.jetbrains.kotlin.jvm")
   id("java-library")
-  `maven-publish`
-}
-
-group = "web5"
-version = "0.0.0"
-
-java {
-  withJavadocJar()
-  withSourcesJar()
-}
-
-publishing {
-  publications {
-    create<MavenPublication>("web5Credentials") {
-      from(components["java"])
-    }
-  }
 }
 
 repositories {


### PR DESCRIPTION
# Overview
This is an example of how we'll publish things using jitpack.io. This setup follows the one in https://github.com/jitpack/gradle-modular

# Description
Jitpack is very simple to set up. And even easier to consume. The README was updated to reflect this. CI also now has a `publishToMavenLocal` task. 

# How Has This Been Tested?
In [jitpack.io](https://jitpack.io/#TBD54566975/web5-sdk-kotlin/) you can see the successful build log. I triggered this build by adding `implementation("com.github.TBD54566975:web5-sdk-kotlin:PR40-SNAPSHOT")` to a local project. 

## References
https://docs.jitpack.io/building/
