### PR TITLE
Adding more tests for pex and adding more robust pex handling

### DIFF
--- a/credentials/src/main/kotlin/SSI.kt
+++ b/credentials/src/main/kotlin/SSI.kt
@@ -132,13 +132,11 @@ public data class CreateVcOptions(
  *
  * @property presentationDefinition The definition describing the requirements of what vcs are needed for the verifiable presentation.
  * @property verifiableCredentialJwts The list of verifiable credentials in JWT format to be included in the presentation.
- * @property resolver Used to verify the validity of the VcJwts that are passed in to be included in the presentation.
  * @property holder The decentralized identifier for the holder of the presentation.
  */
 public data class CreateVpOptions(
   val presentationDefinition: PresentationDefinitionV2,
   val verifiableCredentialJwts: List<VcJwt>,
-  val resolver: DIDResolver,
   val holder: String, // TODO: Remove this
 )
 
@@ -242,13 +240,6 @@ public class VerifiablePresentation private constructor() {
      */
     @Throws(Exception::class)
     public fun create(signOptions: SignOptions, createVpOptions: CreateVpOptions): VpJwt {
-      // Verify VC Validity
-      for (vcJwt: VcJwt in createVpOptions.verifiableCredentialJwts) {
-        if (!VerifiableCredential.verify(vcJwt, createVpOptions.resolver)) {
-          throw Exception("One or more VcJwts are invalid.")
-        }
-      }
-
       validatePresentationFrom(createVpOptions.presentationDefinition, createVpOptions.verifiableCredentialJwts)
 
       val vcMap: MutableMap<String, Any> = HashMap()

--- a/credentials/src/test/kotlin/SSITest.kt
+++ b/credentials/src/test/kotlin/SSITest.kt
@@ -168,7 +168,7 @@ class SSITest {
     )
 
     val createVpOptions =
-      CreateVpOptions(btcAddressPd, arrayListOf(vcJwt), SimpleResolver(didDocument), did)
+      CreateVpOptions(btcAddressPd, arrayListOf(vcJwt), did)
     val vpJwt: VpJwt = VerifiablePresentation.create(signOptions, createVpOptions)
 
     assertTrue(VerifiablePresentation.verify(vpJwt, SimpleResolver(didDocument)))
@@ -197,7 +197,7 @@ class SSITest {
     )
 
     val createVpOptions =
-      CreateVpOptions(btcAddressPd, arrayListOf(vcJwt), SimpleResolver(didDocument), did)
+      CreateVpOptions(btcAddressPd, arrayListOf(vcJwt), did)
 
     val exception = assertThrows<Exception> {
       VerifiablePresentation.create(signOptions, createVpOptions)
@@ -228,7 +228,6 @@ class SSITest {
       CreateVpOptions(
         btcAddressFirstNamePd,
         arrayListOf(btcAddressVcJwt),
-        SimpleResolver(didDocument),
         did
       )
 
@@ -259,7 +258,6 @@ class SSITest {
     val createVpOptions = CreateVpOptions(
       btcAddressFirstNamePd,
       arrayListOf(btcAddressVcJwt, btcAddressVcJwt),
-      SimpleResolver(didDocument),
       did
     )
 
@@ -292,7 +290,6 @@ class SSITest {
     val createVpOptions = CreateVpOptions(
       btcAddressFirstNamePd,
       arrayListOf(btcAddressVcJwt, firstNameVcJwt),
-      SimpleResolver(didDocument),
       did
     )
 
@@ -314,7 +311,7 @@ class SSITest {
       )
     )
 
-    val createVpOptions = CreateVpOptions(btcAddressFirstNamePd, arrayListOf(), SimpleResolver(didDocument), did)
+    val createVpOptions = CreateVpOptions(btcAddressFirstNamePd, arrayListOf(), did)
 
     val exception = assertThrows<Exception> {
       VerifiablePresentation.create(signOptions, createVpOptions)
@@ -339,7 +336,7 @@ class SSITest {
     )
 
     val createVpOptions =
-      CreateVpOptions(btcAddressFirstNamePd, arrayListOf("invalidjwt"), SimpleResolver(didDocument), did)
+      CreateVpOptions(btcAddressFirstNamePd, arrayListOf("invalidjwt"), did)
 
     val exception = assertThrows<Exception> {
       VerifiablePresentation.create(signOptions, createVpOptions)

--- a/credentials/src/test/kotlin/SSITest.kt
+++ b/credentials/src/test/kotlin/SSITest.kt
@@ -236,7 +236,7 @@ class SSITest {
     }
 
     assertTrue(
-      exception.message!!.contains("Required field firstNameId is not satisfied in InputDescriptor")!!
+      exception.message!!.contains("Required field firstNameId is not satisfied in InputDescriptor")
     )
   }
 

--- a/credentials/src/test/kotlin/SSITest.kt
+++ b/credentials/src/test/kotlin/SSITest.kt
@@ -205,7 +205,7 @@ class SSITest {
 
     assertTrue(
       exception
-        .message?.contains("is not satisfied in InputDescriptor")!!
+        .message!!.contains("is not satisfied in InputDescriptor")
     )
   }
 
@@ -237,7 +237,7 @@ class SSITest {
     }
 
     assertTrue(
-      exception.message?.contains("Required field firstNameId is not satisfied in InputDescriptor")!!
+      exception.message!!.contains("Required field firstNameId is not satisfied in InputDescriptor")!!
     )
   }
 
@@ -268,7 +268,7 @@ class SSITest {
     }
 
     assertTrue(
-      exception.message?.contains("Required field firstNameId is not satisfied in InputDescriptor")!!
+      exception.message!!.contains("Required field firstNameId is not satisfied in InputDescriptor")!!
     )
   }
 
@@ -321,7 +321,7 @@ class SSITest {
     }
 
     assertTrue(
-      exception.message?.contains("Required field btcAddressId is not satisfied in InputDescriptor")!!
+      exception.message!!.contains("Required field btcAddressId is not satisfied in InputDescriptor")!!
     )
   }
 
@@ -346,7 +346,7 @@ class SSITest {
     }
 
     assertTrue(
-      exception.message?.contains("Invalid serialized unsecured/JWS/JWE")!!
+      exception.message!!.contains("Invalid serialized unsecured/JWS/JWE")!!
     )
   }
 

--- a/credentials/src/test/kotlin/SSITest.kt
+++ b/credentials/src/test/kotlin/SSITest.kt
@@ -2,12 +2,14 @@ package web5.credentials
 
 import com.nimbusds.jose.jwk.JWK
 import foundation.identity.did.DIDDocument
+import foundation.identity.jsonld.JsonLDObject
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertThrows
 import uniresolver.result.ResolveDataModelResult
 import uniresolver.result.ResolveRepresentationResult
 import uniresolver.w3c.DIDResolver
 import web5.credentials.model.ConstraintsV2
+import web5.credentials.model.CredentialStatus
 import web5.credentials.model.CredentialSubject
 import web5.credentials.model.FieldV2
 import web5.credentials.model.InputDescriptorV2
@@ -19,6 +21,7 @@ import java.util.Date
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -109,6 +112,40 @@ class SSITest {
   }
 
   @Test
+  fun `creates credential status vc with valid vc builder returns vc jwt`() {
+    val credentialSubject = CredentialSubject.builder()
+      .id(URI.create(did))
+      .claims(mutableMapOf<String, Any>().apply { this["firstName"] = "Bobby" })
+      .build()
+
+    val properties: MutableMap<String, Any> = HashMap()
+    properties["statusPurpose"] = "revocation"
+    properties["statusListIndex"] = "94567"
+    properties["statusListCredential"] = "https://example.com/credentials/status/3"
+
+    val credentialStatus: CredentialStatus = CredentialStatus.builder()
+      .base(
+        JsonLDObject.builder()
+          .id(URI.create("https://example.com/credentials/status/3#94567"))
+          .type("StatusList2021Entry")
+          .properties(properties)
+          .build()
+      )
+      .build()
+
+    val vc: VerifiableCredentialType = VerifiableCredentialType.builder()
+      .id(URI.create(UUID.randomUUID().toString()))
+      .credentialSubject(credentialSubject)
+      .credentialStatus(credentialStatus)
+      .issuer(URI.create(did))
+      .issuanceDate(Date())
+      .build()
+
+    val vcJwt: VcJwt = VerifiableCredential.create(signOptions, null, vc)
+    assertTrue(VerifiableCredential.verify(vcJwt, SimpleResolver(didDocument)))
+  }
+
+  @Test
   fun `fulfills presentation definition with valid vcjwt`() {
     val credentialSubject = CredentialSubject.builder()
       .id(URI.create(did))
@@ -124,7 +161,14 @@ class SSITest {
 
     val vcJwt: VcJwt = VerifiableCredential.create(signOptions, null, vc)
 
-    val createVpOptions = CreateVpOptions(getPresentationDefinition(), arrayListOf(vcJwt), did)
+    val btcAddressPd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(fields = listOf(buildField(paths = arrayOf("$.credentialSubject.btcAddress"))))
+      )
+    )
+
+    val createVpOptions =
+      CreateVpOptions(btcAddressPd, arrayListOf(vcJwt), SimpleResolver(didDocument), did)
     val vpJwt: VpJwt = VerifiablePresentation.create(signOptions, createVpOptions)
 
     assertTrue(VerifiablePresentation.verify(vpJwt, SimpleResolver(didDocument)))
@@ -146,7 +190,14 @@ class SSITest {
 
     val vcJwt: VcJwt = VerifiableCredential.create(signOptions, null, vc)
 
-    val createVpOptions = CreateVpOptions(getPresentationDefinition(), arrayListOf(vcJwt), did)
+    val btcAddressPd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(fields = listOf(buildField(paths = arrayOf("$.credentialSubject.btcAddress"))))
+      )
+    )
+
+    val createVpOptions =
+      CreateVpOptions(btcAddressPd, arrayListOf(vcJwt), SimpleResolver(didDocument), did)
 
     val exception = assertThrows<Exception> {
       VerifiablePresentation.create(signOptions, createVpOptions)
@@ -154,8 +205,193 @@ class SSITest {
 
     assertTrue(
       exception
-        .message?.contains("There are no useable Vcs that correspond to the presentation definition")!!
+        .message?.contains("is not satisfied in InputDescriptor")!!
     )
+  }
+
+  @Test
+  fun `should throw exception when only btcAddress VcJwt is passed`() {
+    val btcAddressFirstNamePd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(
+          fields = listOf(
+            buildField(id = "btcAddressId", paths = arrayOf("$.credentialSubject.btcAddress")),
+            buildField(id = "firstNameId", paths = arrayOf("$.credentialSubject.firstName"))
+          )
+        )
+      )
+    )
+
+    val btcAddressVcJwt = buildVcJwt(did = did, signOptions, mapOf("btcAddress" to "btcAddress123"))
+
+    val createVpOptions =
+      CreateVpOptions(
+        btcAddressFirstNamePd,
+        arrayListOf(btcAddressVcJwt),
+        SimpleResolver(didDocument),
+        did
+      )
+
+    val exception = assertThrows<Exception> {
+      VerifiablePresentation.create(signOptions, createVpOptions)
+    }
+
+    assertTrue(
+      exception.message?.contains("Required field firstNameId is not satisfied in InputDescriptor")!!
+    )
+  }
+
+  @Test
+  fun `should throw exception when two identical btcAddress VcJwts are passed`() {
+    val btcAddressFirstNamePd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(
+          fields = listOf(
+            buildField(id = "btcAddressId", paths = arrayOf("$.credentialSubject.btcAddress")),
+            buildField(id = "firstNameId", paths = arrayOf("$.credentialSubject.firstName"))
+          )
+        )
+      )
+    )
+
+    val btcAddressVcJwt = buildVcJwt(did = did, signOptions, mapOf("btcAddress" to "btcAddress123"))
+
+    val createVpOptions = CreateVpOptions(
+      btcAddressFirstNamePd,
+      arrayListOf(btcAddressVcJwt, btcAddressVcJwt),
+      SimpleResolver(didDocument),
+      did
+    )
+
+    val exception = assertThrows<Exception> {
+      VerifiablePresentation.create(signOptions, createVpOptions)
+    }
+
+    assertTrue(
+      exception.message?.contains("Required field firstNameId is not satisfied in InputDescriptor")!!
+    )
+  }
+
+  @Test
+  fun `should verify successfully when both required VcJwts are passed`() {
+    val btcAddressFirstNamePd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(
+          fields = listOf(
+            buildField(id = "btcAddressId", paths = arrayOf("$.credentialSubject.btcAddress")),
+            buildField(id = "firstNameId", paths = arrayOf("$.credentialSubject.firstName"))
+          )
+        )
+      )
+    )
+
+    val btcAddressVcJwt = buildVcJwt(did = did, signOptions, mapOf("btcAddress" to "btcAddress123"))
+    val firstNameVcJwt = buildVcJwt(did = did, signOptions, mapOf("firstName" to "bob"))
+
+
+    val createVpOptions = CreateVpOptions(
+      btcAddressFirstNamePd,
+      arrayListOf(btcAddressVcJwt, firstNameVcJwt),
+      SimpleResolver(didDocument),
+      did
+    )
+
+    val vpJwt: VpJwt = VerifiablePresentation.create(signOptions, createVpOptions)
+
+    assertTrue(VerifiablePresentation.verify(vpJwt, SimpleResolver(didDocument)))
+  }
+
+  @Test
+  fun `should throw exception when VCJwts is an empty list`() {
+    val btcAddressFirstNamePd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(
+          fields = listOf(
+            buildField(id = "btcAddressId", paths = arrayOf("$.credentialSubject.btcAddress")),
+            buildField(id = "firstNameId", paths = arrayOf("$.credentialSubject.firstName"))
+          )
+        )
+      )
+    )
+
+    val createVpOptions = CreateVpOptions(btcAddressFirstNamePd, arrayListOf(), SimpleResolver(didDocument), did)
+
+    val exception = assertThrows<Exception> {
+      VerifiablePresentation.create(signOptions, createVpOptions)
+    }
+
+    assertTrue(
+      exception.message?.contains("Required field btcAddressId is not satisfied in InputDescriptor")!!
+    )
+  }
+
+  @Test
+  fun `should throw exception when VCJwts is invalid`() {
+    val btcAddressFirstNamePd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(
+          fields = listOf(
+            buildField(id = "btcAddressId", paths = arrayOf("$.credentialSubject.btcAddress")),
+            buildField(id = "firstNameId", paths = arrayOf("$.credentialSubject.firstName"))
+          )
+        )
+      )
+    )
+
+    val createVpOptions =
+      CreateVpOptions(btcAddressFirstNamePd, arrayListOf("invalidjwt"), SimpleResolver(didDocument), did)
+
+    val exception = assertThrows<Exception> {
+      VerifiablePresentation.create(signOptions, createVpOptions)
+    }
+
+    assertTrue(
+      exception.message?.contains("Invalid serialized unsecured/JWS/JWE")!!
+    )
+  }
+
+  @Test
+  fun `should select matching VcJwts`() {
+    val btcAddressFirstNamePd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(
+          fields = listOf(
+            buildField(id = "btcAddressId", paths = arrayOf("$.credentialSubject.btcAddress")),
+            buildField(id = "firstNameId", paths = arrayOf("$.credentialSubject.firstName"))
+          )
+        )
+      )
+    )
+
+    val btcAddressVcJwt = buildVcJwt(did = did, signOptions, mapOf("btcAddress" to "btcAddress123"))
+    val firstNameVcJwt = buildVcJwt(did = did, signOptions, mapOf("firstName" to "bob"))
+
+    val selectedVcJwts =
+      VerifiablePresentation.selectFrom(btcAddressFirstNamePd, listOf(btcAddressVcJwt, firstNameVcJwt))
+
+    assertEquals(2, selectedVcJwts.size)
+  }
+
+  @Test
+  fun `should return empty list if no matching VcJwts found`() {
+    val btcAddressFirstNamePd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(
+          fields = listOf(
+            buildField(id = "btcAddressId", paths = arrayOf("$.credentialSubject.btcAddress")),
+            buildField(id = "firstNameId", paths = arrayOf("$.credentialSubject.firstName"))
+          )
+        )
+      )
+    )
+
+    val btcAddressVcJwt = buildVcJwt(did = did, signOptions, mapOf("lightningAddress" to "lightningAddress123"))
+    val firstNameVcJwt = buildVcJwt(did = did, signOptions, mapOf("lastName" to "bobby"))
+
+    val selectedVcJwts =
+      VerifiablePresentation.selectFrom(btcAddressFirstNamePd, listOf(btcAddressVcJwt, firstNameVcJwt))
+
+    assertEquals(0, selectedVcJwts.size)
   }
 }
 
@@ -169,23 +405,48 @@ class SimpleResolver(var didDocument: DIDDocument) : DIDResolver {
   }
 }
 
-fun getPresentationDefinition(): PresentationDefinitionV2 {
+fun buildPresentationDefinition(
+  id: String = "test-pd-id",
+  name: String = "simple PD",
+  purpose: String = "pd for testing",
+  inputDescriptors: List<InputDescriptorV2> = listOf()
+): PresentationDefinitionV2 {
   return PresentationDefinitionV2(
-    id = "test-pd-id",
-    name = "simple PD",
-    purpose = "pd for testing",
-    inputDescriptors = listOf(
-      InputDescriptorV2(
-        id = "whatever",
-        purpose = "id for testing",
-        constraints = ConstraintsV2(
-          fields = listOf(
-            FieldV2(
-              path = listOf("$.credentialSubject.btcAddress")
-            )
-          )
-        )
-      )
-    )
+    id = id,
+    name = name,
+    purpose = purpose,
+    inputDescriptors = inputDescriptors
   )
+}
+
+fun buildInputDescriptor(
+  id: String = "whatever",
+  purpose: String = "id for testing",
+  fields: List<FieldV2> = listOf()
+): InputDescriptorV2 {
+  return InputDescriptorV2(
+    id = id,
+    purpose = purpose,
+    constraints = ConstraintsV2(fields = fields)
+  )
+}
+
+fun buildField(id: String? = null, vararg paths: String): FieldV2 {
+  return FieldV2(id = id, path = paths.toList())
+}
+
+fun buildVcJwt(did: String, signOptions: SignOptions, claims: Map<String, Any>): VcJwt {
+  val credentialSubject = CredentialSubject.builder()
+    .id(URI.create(did))
+    .claims(claims.toMutableMap())
+    .build()
+
+  val vc: VerifiableCredentialType = VerifiableCredentialType.builder()
+    .id(URI.create(UUID.randomUUID().toString()))
+    .credentialSubject(credentialSubject)
+    .issuer(URI.create(did))
+    .issuanceDate(Date())
+    .build()
+
+  return VerifiableCredential.create(signOptions, null, vc)
 }

--- a/credentials/src/test/kotlin/SSITest.kt
+++ b/credentials/src/test/kotlin/SSITest.kt
@@ -343,7 +343,7 @@ class SSITest {
     }
 
     assertTrue(
-      exception.message!!.contains("Invalid serialized unsecured/JWS/JWE")!!
+      exception.message!!.contains("Invalid serialized unsecured/JWS/JWE")
     )
   }
 

--- a/credentials/src/test/kotlin/SSITest.kt
+++ b/credentials/src/test/kotlin/SSITest.kt
@@ -266,7 +266,7 @@ class SSITest {
     }
 
     assertTrue(
-      exception.message!!.contains("Required field firstNameId is not satisfied in InputDescriptor")!!
+      exception.message!!.contains("Required field firstNameId is not satisfied in InputDescriptor")
     )
   }
 

--- a/credentials/src/test/kotlin/SSITest.kt
+++ b/credentials/src/test/kotlin/SSITest.kt
@@ -318,7 +318,7 @@ class SSITest {
     }
 
     assertTrue(
-      exception.message!!.contains("Required field btcAddressId is not satisfied in InputDescriptor")!!
+      exception.message!!.contains("Required field btcAddressId is not satisfied in InputDescriptor")
     )
   }
 


### PR DESCRIPTION
# Overview
Adding more tests for pex and adding more robust pex handling

# Description
Adding      
`validatePresentationFrom(createVpOptions.presentationDefinition, createVpOptions.verifiableCredentialJwts)` which does field validation for determining if the VCs provided are valid for the presentation definition.

```

/**
 * Validates a list of Verifiable Credentials (VcJwts) against a presentation definition.
 *
 * This method checks the presentation definition and the list of Verifiable Credentials to ensure
 * that the required fields in the definition are satisfied by the provided credentials.
 *
 * Currently, if the presentation definition contains submission requirements, or if any required field in an input
 * descriptor is not satisfied by the provided credentials, an exception is thrown.
 *
 * ### Throws
 * - [NotImplementedError] if the Presentation Definition contains Submission Requirements or if a Field Filter is included.
 * - [Exception] if any required field is not satisfied in the given InputDescriptor.
 *
 * @param presentationDefinition The [PresentationDefinitionV2] object representing the presentation's definition.
 * @param vcJwts The list of [VcJwt] representing the Verifiable Credentials to be validated against the presentation definition.
 * @throws Exception If a required field is not satisfied in a given InputDescriptor.
 */
```