### PR TITLE
Marks some deps as part of the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,30 @@ All the web5 libraries are published on [JitPack](https://jitpack.io). To start 
 
 ```kotlin
 repositories {
-    maven(url = "https://jitpack.io")
+  maven(url = "https://jitpack.io")
+  maven("https://repo.danubetech.com/repository/maven-public/")
 }
 
 dependencies {
-    implementation("com.github.TBD54566975:web5-sdk-kotlin:master-SNAPSHOT")
+  implementation("com.github.TBD54566975:web5-sdk-kotlin:master-SNAPSHOT")
 }
 ```
 
+NOTE: The repository at `https://repo.danubetech.com/repository/maven-public/` is required for resolving transitive
+dependencies.
+
 If you want to refer to a specific release, then replace the `master-SNAPSHOT` with release tag.
 
-If you want to pull a PR, then replace `master-SNAPSHOT` using the template `PR<NR>-SNAPSHOT`. For example `PR40-SNAPSHOT`.
+If you want to pull a PR, then replace `master-SNAPSHOT` using the template `PR<NR>-SNAPSHOT`. For
+example `PR40-SNAPSHOT`.
 
 If you want to depend on a single module, like `credentials`, then use the following dependencies
+
 ```kotlin
 dependencies {
   implementation("com.github.TBD54566975.web5-sdk-kotlin:credentials:master-SNAPSHOT")
 }
 ```
-
 
 # Building
 
@@ -43,6 +48,7 @@ To build and run test just run:
 ```
 
 # Other Docs
+
 * [Guidelines](./CONVENTIONS.md)
 * [Code of Conduct](./CODE_OF_CONDUCT.md)
 * [Governance](./GOVERNANCE.md)

--- a/credentials/build.gradle.kts
+++ b/credentials/build.gradle.kts
@@ -15,12 +15,14 @@ repositories {
 dependencies {
   testImplementation(kotlin("test"))
 
+  api("com.danubetech:verifiable-credentials-java:1.5.0")
+  api("com.nimbusds:nimbus-jose-jwt:9.34")
+  api("decentralized-identity:did-common-java:1.9.0")
+  api("decentralized-identity:uni-resolver-core:0.13.0")
+
   implementation("com.github.richardbergquist:java-multicodec:main-SNAPSHOT")
   implementation("com.google.crypto.tink:tink:1.10.0")
-  implementation("decentralized-identity:uni-resolver-core:0.13.0")
-  implementation("com.danubetech:verifiable-credentials-java:1.5.0")
   implementation("com.nfeld.jsonpathkt:jsonpathkt:2.0.1")
-  implementation("com.googlecode.json-simple:json-simple:1.1.1")
 }
 
 tasks.test {

--- a/credentials/src/main/kotlin/SSI.kt
+++ b/credentials/src/main/kotlin/SSI.kt
@@ -18,7 +18,6 @@ import foundation.identity.did.DID
 import foundation.identity.did.DIDDocument
 import foundation.identity.did.VerificationMethod
 import io.ipfs.multibase.Multibase
-import org.json.simple.JSONValue
 import uniresolver.result.ResolveDataModelResult
 import uniresolver.w3c.DIDResolver
 import web5.credentials.model.CredentialStatus
@@ -299,7 +298,7 @@ private fun selectFrom(presentationDefinition: PresentationDefinitionV2, vcJwts:
 
             // Optional fields are not needed to complete the required fields in the presentation definition
             if (field.optional != null && field.optional) {
-              continue;
+              continue
             }
 
             for (path: String in field.path) {
@@ -331,7 +330,7 @@ private fun evaluateJsonPath(vcJwt: VcJwt, path: String): String? {
   val vc: VerifiableCredentialType =
     FromJwtConverter.fromJwtVerifiableCredential(JwtVerifiableCredential.fromCompactSerialization(vcJwt))
 
-  val vcJsonString: String = JSONValue.toJSONString(vc.jsonObject)
+  val vcJsonString: String = vc.toJson()
   val result: String? = JsonPath.parse(vcJsonString)?.read<String>(path)
 
   return result


### PR DESCRIPTION
# Overview
Code that depends on `web5-sdk-kotlin` currently needs to pull dependencies that are part of public signatures. This PR fixes this. 

# Description
For a more details description, see https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation

# How Has This Been Tested?
Followed the instructions in a local repository which exercises full functionality.

