### PR TITLE
updating pex with pres submission

### DIFF
--- a/credentials/src/main/kotlin/SSI.kt
+++ b/credentials/src/main/kotlin/SSI.kt
@@ -335,7 +335,7 @@ public object VerifiablePresentation {
   }
 
   /**
-   * Validates a list of Verifiable Credentials (VcJwts) against a presentation definition and generates a presentation submission
+   * Validates a list of Verifiable Credentials (VcJwts) against a presentation definition and generates a presentation submission.
    *
    * This method checks the presentation definition and the list of Verifiable Credentials to ensure
    * that the required fields in the definition are satisfied by the provided credentials.
@@ -343,16 +343,10 @@ public object VerifiablePresentation {
    * Currently, if the presentation definition contains submission requirements, or if any required field in an input
    * descriptor is not satisfied by the provided credentials, an exception is thrown.
    *
-   * A compliant presentation submission is returned
-   *
-   * ### Throws
-   * - [NotImplementedError] if the Presentation Definition contains Submission Requirements or if a Field Filter is implemented.
-   * - [Exception] if any required field is not satisfied in the given InputDescriptor.
-   *
    * @param presentationDefinition The [PresentationDefinitionV2] object representing the presentation's definition.
    * @param vcJwts The list of [VcJwt] representing the Verifiable Credentials to be validated against the presentation definition.
    * @throws Exception If a required field is not satisfied in a given InputDescriptor.
-   * @return the generated presentation submission.
+   * @return the generated compliant presentation submission.
    */
   @Throws(Exception::class)
   private fun generatePresentationSubmissionFrom(

--- a/credentials/src/main/kotlin/SSI.kt
+++ b/credentials/src/main/kotlin/SSI.kt
@@ -157,7 +157,7 @@ public data class CreateVpOptions(
  * @property payload The payload of the JWT, containing the claims and the issuer of the token.
  * @property signature The signature of the JWT, used for verifying the integrity of the token.
  */
-public data class DecodedVcJwt(
+public data class DecodedJwt(
   val header: Any,
   val payload: Any,
   val signature: String,
@@ -241,6 +241,22 @@ public object VerifiableCredential {
     return JwtVerifiableCredential.fromCompactSerialization(vcJWT)
       .verify_Ed25519_EdDSA(publicKeyJWK.toOctetKeyPair())
   }
+
+  /**
+   * Decodes a verifiable credential JWT into its header, payload, and signature components.
+   *
+   * @param vcJWT The JWT representation of the verifiable credential to be decoded.
+   * @return A [DecodedJwt] object containing the decoded components.
+   */
+  public fun decode(vcJWT: VcJwt): DecodedJwt {
+    val (encodedHeader, encodedPayload, encodedSignature) = vcJWT.split('.')
+
+    return DecodedJwt(
+      header = String(Base64.getDecoder().decode(encodedHeader)),
+      payload = String(Base64.getDecoder().decode(encodedPayload)),
+      signature = encodedSignature
+    )
+  }
 }
 
 /**
@@ -296,12 +312,12 @@ public object VerifiablePresentation {
    * Decodes a verifiable presentation JWT into its header, payload, and signature components.
    *
    * @param vpJWT The JWT representation of the verifiable presentation to be decoded.
-   * @return A [DecodedVcJwt] object containing the decoded components.
+   * @return A [DecodedJwt] object containing the decoded components.
    */
-  public fun decode(vpJWT: VpJwt): DecodedVcJwt {
+  public fun decode(vpJWT: VpJwt): DecodedJwt {
     val (encodedHeader, encodedPayload, encodedSignature) = vpJWT.split('.')
 
-    return DecodedVcJwt(
+    return DecodedJwt(
       header = String(Base64.getDecoder().decode(encodedHeader)),
       payload = String(Base64.getDecoder().decode(encodedPayload)),
       signature = encodedSignature

--- a/credentials/src/main/kotlin/SSI.kt
+++ b/credentials/src/main/kotlin/SSI.kt
@@ -351,7 +351,7 @@ public object VerifiablePresentation {
 
             // Optional fields are not needed to complete the required fields in the presentation definition
             if (field.optional != null && field.optional) {
-              continue;
+              continue
             }
 
             for (path: String in field.path) {

--- a/credentials/src/main/kotlin/model/SSITypes.kt
+++ b/credentials/src/main/kotlin/model/SSITypes.kt
@@ -1,7 +1,8 @@
 package web5.credentials.model
 
-/**
- * Verifiable Credentials
+import com.fasterxml.jackson.annotation.JsonInclude
+
+/** Verifiable Credentials
  *
  * A verifiable credential is a tamper-evident credential that has authorship that can be cryptographically verified.
  *
@@ -33,6 +34,7 @@ public typealias VerifiablePresentationType = com.danubetech.verifiablecredentia
  *
  * @see [Presentation Definition](https://identity.foundation/presentation-exchange/#presentation-definition)
  */
+
 public class PresentationDefinitionV2(
   public val id: String,
   public val name: String? = null,
@@ -172,4 +174,26 @@ public class FilterV2(
   public val not: Any? = null,
   public val pattern: String? = null,
   public val type: String
+)
+
+/**
+ * Represents a presentation submission object.
+ *
+ * @see [Presentation Submission](https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-submission)
+ */
+public data class PresentationSubmission(
+  val id: String,
+  val definitionId: String,
+  val descriptorMap: List<DescriptorMap>
+)
+
+/**
+ * Represents descriptor map for a presentation submission.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public data class DescriptorMap(
+  val id: String,
+  val path: String,
+  val pathNested: DescriptorMap? = null,
+  val format: String
 )

--- a/credentials/src/test/kotlin/SSITest.kt
+++ b/credentials/src/test/kotlin/SSITest.kt
@@ -4,7 +4,6 @@ import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jwt.SignedJWT
 import foundation.identity.did.DIDDocument
 import foundation.identity.jsonld.JsonLDObject
-import jakarta.json.JsonObject
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertThrows
 import uniresolver.result.ResolveDataModelResult

--- a/credentials/src/test/kotlin/SSITest.kt
+++ b/credentials/src/test/kotlin/SSITest.kt
@@ -2,12 +2,14 @@ package web5.credentials
 
 import com.nimbusds.jose.jwk.JWK
 import foundation.identity.did.DIDDocument
+import foundation.identity.jsonld.JsonLDObject
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertThrows
 import uniresolver.result.ResolveDataModelResult
 import uniresolver.result.ResolveRepresentationResult
 import uniresolver.w3c.DIDResolver
 import web5.credentials.model.ConstraintsV2
+import web5.credentials.model.CredentialStatus
 import web5.credentials.model.CredentialSubject
 import web5.credentials.model.FieldV2
 import web5.credentials.model.InputDescriptorV2
@@ -19,6 +21,7 @@ import java.util.Date
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -109,6 +112,40 @@ class SSITest {
   }
 
   @Test
+  fun `creates credential status vc with valid vc builder returns vc jwt`() {
+    val credentialSubject = CredentialSubject.builder()
+      .id(URI.create(did))
+      .claims(mutableMapOf<String, Any>().apply { this["firstName"] = "Bobby" })
+      .build()
+
+    val properties: MutableMap<String, Any> = HashMap()
+    properties["statusPurpose"] = "revocation"
+    properties["statusListIndex"] = "94567"
+    properties["statusListCredential"] = "https://example.com/credentials/status/3"
+
+    val credentialStatus: CredentialStatus = CredentialStatus.builder()
+      .base(
+        JsonLDObject.builder()
+          .id(URI.create("https://example.com/credentials/status/3#94567"))
+          .type("StatusList2021Entry")
+          .properties(properties)
+          .build()
+      )
+      .build()
+
+    val vc: VerifiableCredentialType = VerifiableCredentialType.builder()
+      .id(URI.create(UUID.randomUUID().toString()))
+      .credentialSubject(credentialSubject)
+      .credentialStatus(credentialStatus)
+      .issuer(URI.create(did))
+      .issuanceDate(Date())
+      .build()
+
+    val vcJwt: VcJwt = VerifiableCredential.create(signOptions, null, vc)
+    assertTrue(VerifiableCredential.verify(vcJwt, SimpleResolver(didDocument)))
+  }
+
+  @Test
   fun `fulfills presentation definition with valid vcjwt`() {
     val credentialSubject = CredentialSubject.builder()
       .id(URI.create(did))
@@ -124,10 +161,29 @@ class SSITest {
 
     val vcJwt: VcJwt = VerifiableCredential.create(signOptions, null, vc)
 
-    val createVpOptions = CreateVpOptions(getPresentationDefinition(), arrayListOf(vcJwt), did)
+    val btcAddressPd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(fields = listOf(buildField(paths = arrayOf("$.credentialSubject.btcAddress"))))
+      )
+    )
+
+    val createVpOptions =
+      CreateVpOptions(btcAddressPd, arrayListOf(vcJwt), did)
     val vpJwt: VpJwt = VerifiablePresentation.create(signOptions, createVpOptions)
 
     assertTrue(VerifiablePresentation.verify(vpJwt, SimpleResolver(didDocument)))
+
+    val parts = vpJwt.split(".")
+    val header = String(Base64.getDecoder().decode(parts[0]))
+    val payload = String(Base64.getDecoder().decode(parts[1]))
+
+    // Header Checks
+    assertTrue { header.contains("\"alg\":\"") }
+    assertTrue { header.contains("\"typ\":\"JWT\"") }
+
+    // Payload Checks
+    assertTrue { payload.contains("\"iss\":\"") }
+    assertTrue { payload.contains("\"sub\":\"") }
   }
 
   @Test
@@ -146,7 +202,14 @@ class SSITest {
 
     val vcJwt: VcJwt = VerifiableCredential.create(signOptions, null, vc)
 
-    val createVpOptions = CreateVpOptions(getPresentationDefinition(), arrayListOf(vcJwt), did)
+    val btcAddressPd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(fields = listOf(buildField(paths = arrayOf("$.credentialSubject.btcAddress"))))
+      )
+    )
+
+    val createVpOptions =
+      CreateVpOptions(btcAddressPd, arrayListOf(vcJwt), did)
 
     val exception = assertThrows<Exception> {
       VerifiablePresentation.create(signOptions, createVpOptions)
@@ -154,8 +217,190 @@ class SSITest {
 
     assertTrue(
       exception
-        .message?.contains("There are no useable Vcs that correspond to the presentation definition")!!
+        .message!!.contains("is not satisfied in InputDescriptor")
     )
+  }
+
+  @Test
+  fun `should throw exception when only btcAddress VcJwt is passed`() {
+    val btcAddressFirstNamePd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(
+          fields = listOf(
+            buildField(id = "btcAddressId", paths = arrayOf("$.credentialSubject.btcAddress")),
+            buildField(id = "firstNameId", paths = arrayOf("$.credentialSubject.firstName"))
+          )
+        )
+      )
+    )
+
+    val btcAddressVcJwt = buildVcJwt(did = did, signOptions, mapOf("btcAddress" to "btcAddress123"))
+
+    val createVpOptions =
+      CreateVpOptions(
+        btcAddressFirstNamePd,
+        arrayListOf(btcAddressVcJwt),
+        did
+      )
+
+    val exception = assertThrows<Exception> {
+      VerifiablePresentation.create(signOptions, createVpOptions)
+    }
+
+    assertTrue(
+      exception.message!!.contains("Required field firstNameId is not satisfied in InputDescriptor")
+    )
+  }
+
+  @Test
+  fun `should throw exception when two identical btcAddress VcJwts are passed`() {
+    val btcAddressFirstNamePd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(
+          fields = listOf(
+            buildField(id = "btcAddressId", paths = arrayOf("$.credentialSubject.btcAddress")),
+            buildField(id = "firstNameId", paths = arrayOf("$.credentialSubject.firstName"))
+          )
+        )
+      )
+    )
+
+    val btcAddressVcJwt = buildVcJwt(did = did, signOptions, mapOf("btcAddress" to "btcAddress123"))
+
+    val createVpOptions = CreateVpOptions(
+      btcAddressFirstNamePd,
+      arrayListOf(btcAddressVcJwt, btcAddressVcJwt),
+      did
+    )
+
+    val exception = assertThrows<Exception> {
+      VerifiablePresentation.create(signOptions, createVpOptions)
+    }
+
+    assertTrue(
+      exception.message!!.contains("Required field firstNameId is not satisfied in InputDescriptor")
+    )
+  }
+
+  @Test
+  fun `should verify successfully when both required VcJwts are passed`() {
+    val btcAddressFirstNamePd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(
+          fields = listOf(
+            buildField(id = "btcAddressId", paths = arrayOf("$.credentialSubject.btcAddress")),
+            buildField(id = "firstNameId", paths = arrayOf("$.credentialSubject.firstName"))
+          )
+        )
+      )
+    )
+
+    val btcAddressVcJwt = buildVcJwt(did = did, signOptions, mapOf("btcAddress" to "btcAddress123"))
+    val firstNameVcJwt = buildVcJwt(did = did, signOptions, mapOf("firstName" to "bob"))
+
+
+    val createVpOptions = CreateVpOptions(
+      btcAddressFirstNamePd,
+      arrayListOf(btcAddressVcJwt, firstNameVcJwt),
+      did
+    )
+
+    val vpJwt: VpJwt = VerifiablePresentation.create(signOptions, createVpOptions)
+
+    assertTrue(VerifiablePresentation.verify(vpJwt, SimpleResolver(didDocument)))
+  }
+
+  @Test
+  fun `should throw exception when VCJwts is an empty list`() {
+    val btcAddressFirstNamePd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(
+          fields = listOf(
+            buildField(id = "btcAddressId", paths = arrayOf("$.credentialSubject.btcAddress")),
+            buildField(id = "firstNameId", paths = arrayOf("$.credentialSubject.firstName"))
+          )
+        )
+      )
+    )
+
+    val createVpOptions = CreateVpOptions(btcAddressFirstNamePd, arrayListOf(), did)
+
+    val exception = assertThrows<Exception> {
+      VerifiablePresentation.create(signOptions, createVpOptions)
+    }
+
+    assertTrue(
+      exception.message!!.contains("Required field btcAddressId is not satisfied in InputDescriptor")
+    )
+  }
+
+  @Test
+  fun `should throw exception when VCJwts is invalid`() {
+    val btcAddressFirstNamePd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(
+          fields = listOf(
+            buildField(id = "btcAddressId", paths = arrayOf("$.credentialSubject.btcAddress")),
+            buildField(id = "firstNameId", paths = arrayOf("$.credentialSubject.firstName"))
+          )
+        )
+      )
+    )
+
+    val createVpOptions =
+      CreateVpOptions(btcAddressFirstNamePd, arrayListOf("invalidjwt"), did)
+
+    val exception = assertThrows<Exception> {
+      VerifiablePresentation.create(signOptions, createVpOptions)
+    }
+
+    assertTrue(
+      exception.message!!.contains("Invalid serialized unsecured/JWS/JWE")
+    )
+  }
+
+  @Test
+  fun `should select matching VcJwts`() {
+    val btcAddressFirstNamePd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(
+          fields = listOf(
+            buildField(id = "btcAddressId", paths = arrayOf("$.credentialSubject.btcAddress")),
+            buildField(id = "firstNameId", paths = arrayOf("$.credentialSubject.firstName"))
+          )
+        )
+      )
+    )
+
+    val btcAddressVcJwt = buildVcJwt(did = did, signOptions, mapOf("btcAddress" to "btcAddress123"))
+    val firstNameVcJwt = buildVcJwt(did = did, signOptions, mapOf("firstName" to "bob"))
+
+    val selectedVcJwts =
+      VerifiablePresentation.selectFrom(btcAddressFirstNamePd, listOf(btcAddressVcJwt, firstNameVcJwt))
+
+    assertEquals(2, selectedVcJwts.size)
+  }
+
+  @Test
+  fun `should return empty list if no matching VcJwts found`() {
+    val btcAddressFirstNamePd = buildPresentationDefinition(
+      inputDescriptors = listOf(
+        buildInputDescriptor(
+          fields = listOf(
+            buildField(id = "btcAddressId", paths = arrayOf("$.credentialSubject.btcAddress")),
+            buildField(id = "firstNameId", paths = arrayOf("$.credentialSubject.firstName"))
+          )
+        )
+      )
+    )
+
+    val btcAddressVcJwt = buildVcJwt(did = did, signOptions, mapOf("lightningAddress" to "lightningAddress123"))
+    val firstNameVcJwt = buildVcJwt(did = did, signOptions, mapOf("lastName" to "bobby"))
+
+    val selectedVcJwts =
+      VerifiablePresentation.selectFrom(btcAddressFirstNamePd, listOf(btcAddressVcJwt, firstNameVcJwt))
+
+    assertEquals(0, selectedVcJwts.size)
   }
 }
 
@@ -169,23 +414,48 @@ class SimpleResolver(var didDocument: DIDDocument) : DIDResolver {
   }
 }
 
-fun getPresentationDefinition(): PresentationDefinitionV2 {
+fun buildPresentationDefinition(
+  id: String = "test-pd-id",
+  name: String = "simple PD",
+  purpose: String = "pd for testing",
+  inputDescriptors: List<InputDescriptorV2> = listOf()
+): PresentationDefinitionV2 {
   return PresentationDefinitionV2(
-    id = "test-pd-id",
-    name = "simple PD",
-    purpose = "pd for testing",
-    inputDescriptors = listOf(
-      InputDescriptorV2(
-        id = "whatever",
-        purpose = "id for testing",
-        constraints = ConstraintsV2(
-          fields = listOf(
-            FieldV2(
-              path = listOf("$.credentialSubject.btcAddress")
-            )
-          )
-        )
-      )
-    )
+    id = id,
+    name = name,
+    purpose = purpose,
+    inputDescriptors = inputDescriptors
   )
+}
+
+fun buildInputDescriptor(
+  id: String = "whatever",
+  purpose: String = "id for testing",
+  fields: List<FieldV2> = listOf()
+): InputDescriptorV2 {
+  return InputDescriptorV2(
+    id = id,
+    purpose = purpose,
+    constraints = ConstraintsV2(fields = fields)
+  )
+}
+
+fun buildField(id: String? = null, vararg paths: String): FieldV2 {
+  return FieldV2(id = id, path = paths.toList())
+}
+
+fun buildVcJwt(did: String, signOptions: SignOptions, claims: Map<String, Any>): VcJwt {
+  val credentialSubject = CredentialSubject.builder()
+    .id(URI.create(did))
+    .claims(claims.toMutableMap())
+    .build()
+
+  val vc: VerifiableCredentialType = VerifiableCredentialType.builder()
+    .id(URI.create(UUID.randomUUID().toString()))
+    .credentialSubject(credentialSubject)
+    .issuer(URI.create(did))
+    .issuanceDate(Date())
+    .build()
+
+  return VerifiableCredential.create(signOptions, null, vc)
 }


### PR DESCRIPTION
# Overview
Adding more tests for pex and adding more robust pex handling

# Description
Adding      
`generatePresentationSubmissionFrom(createVpOptions.presentationDefinition, createVpOptions.verifiableCredentialJwts): PresentationSubmission` which does field validation for determining if the VCs provided are valid for the presentation definition.

```

/**
   * Validates a list of Verifiable Credentials (VcJwts) against a presentation definition and generates a presentation submission
   *
   * This method checks the presentation definition and the list of Verifiable Credentials to ensure
   * that the required fields in the definition are satisfied by the provided credentials.
   *
   * Currently, if the presentation definition contains submission requirements, or if any required field in an input
   * descriptor is not satisfied by the provided credentials, an exception is thrown.
   *
   * A compliant presentation submission is returned
   *
   * ### Throws
   * - [NotImplementedError] if the Presentation Definition contains Submission Requirements or if a Field Filter is implemented.
   * - [Exception] if any required field is not satisfied in the given InputDescriptor.
   *
   * @param presentationDefinition The [PresentationDefinitionV2] object representing the presentation's definition.
   * @param vcJwts The list of [VcJwt] representing the Verifiable Credentials to be validated against the presentation definition.
   * @throws Exception If a required field is not satisfied in a given InputDescriptor.
   * @return the generated presentation submission.
   */
```